### PR TITLE
Removed src attribute while creating iFrame

### DIFF
--- a/src_new/util.js
+++ b/src_new/util.js
@@ -728,7 +728,7 @@ exports.createInvisibleIframe = function() {
 	f.style.border = '0';
 	f.scrolling = 'no';
 	f.frameBorder = '0';
-	f.src = 'about:self';//todo: test by setting empty src on safari
+	//f.src = 'about:self';//todo: test by setting empty src on safari
 	f.style = 'display:none';
 	return f;
 }


### PR DESCRIPTION
[UOE-6208] Removed src attribute while creating iFrame which was not working in Safari.