### PR TITLE
Changes for Native 1.2 support from OW

### DIFF
--- a/src_new/bidManager.js
+++ b/src_new/bidManager.js
@@ -842,27 +842,29 @@ exports.fireTracker = function(bidDetails, action) {
 		const nativeResponse = bidDetails.native.ortb || bidDetails.native;
 
 		const impTrackers = (nativeResponse.eventtrackers || [])
-			.filter(tracker => tracker.event === TRACKER_EVENTS.impression);
-	
-		let {img, js} = impTrackers.reduce((tally, tracker) => {
+			.filter(function(tracker) {
+				tracker.event === TRACKER_EVENTS.impression
+			});
+
+		const tally = {img: [], js: []};
+		impTrackers.forEach(function(tracker) {
 			if (TRACKER_METHODS.hasOwnProperty(tracker.method)) {
-		  		tally[TRACKER_METHODS[tracker.method]].push(tracker.url)
+				tally[TRACKER_METHODS[tracker.method]].push(tracker.url);
 			}
-			return tally;
-	  	}, {img: [], js: []});
+		});
 	
-		if (img.length == 0 && nativeResponse.imptrackers) {
-			img = img.concat(nativeResponse.imptrackers);
+		if (tally.img.length == 0 && nativeResponse.imptrackers) {
+			tally.img = tally.img.concat(nativeResponse.imptrackers);
 		}
-		trackers = img;
+		trackers = tally.img;
 	
-		if (js.length == 0 && nativeResponse.jstracker) {
+		if (tally.js.length == 0 && nativeResponse.jstracker) {
 			// jstracker is already HTML markup
-			js = js.concat([nativeResponse.jstracker]);
+			tally.js = tally.js.concat([nativeResponse.jstracker]);
 		}
-		if (js.length) {
-			util.insertHtmlIntoIframe(js.join('\n'));
-		}	  
+		if (tally.js.length) {
+			util.insertHtmlIntoIframe(tally.js.join('\n'));
+		}
 	}
 
 	(trackers || []).forEach(function(url){refThis.setImageSrcToPixelURL(url,false);});

--- a/src_new/util.js
+++ b/src_new/util.js
@@ -687,6 +687,51 @@ exports.getBididForPMP = function(values, priorityArray){
 	return bidID;
 };
 
+function insertElement(elm, doc, target, asLastChildChild) {
+	doc = doc || document;
+	let parentEl;
+	if (target) {
+	  parentEl = doc.getElementsByTagName(target);
+	} else {
+	  parentEl = doc.getElementsByTagName('head');
+	}
+	try {
+	  parentEl = parentEl.length ? parentEl : doc.getElementsByTagName('body');
+	  if (parentEl.length) {
+		parentEl = parentEl[0];
+		let insertBeforeEl = asLastChildChild ? null : parentEl.firstChild;
+		return parentEl.insertBefore(elm, insertBeforeEl);
+	  }
+	} catch (e) {}
+}
+
+exports.insertHtmlIntoIframe = function(htmlCode) {
+	if (!htmlCode) {
+	  return;
+	}
+  
+	let iframe = document.createElement('iframe');
+	iframe.id = refThis.getUniqueIdentifierStr();
+	iframe.width = 0;
+	iframe.height = 0;
+	iframe.hspace = '0';
+	iframe.vspace = '0';
+	iframe.marginWidth = '0';
+	iframe.marginHeight = '0';
+	iframe.style.display = 'none';
+	iframe.style.height = '0px';
+	iframe.style.width = '0px';
+	iframe.scrolling = 'no';
+	iframe.frameBorder = '0';
+	iframe.allowtransparency = 'true';
+  
+	insertElement(iframe, document, 'body');
+  
+	iframe.contentWindow.document.open();
+	iframe.contentWindow.document.write(htmlCode);
+	iframe.contentWindow.document.close();
+}
+  
 // removeIf(removeNativeRelatedCode)
 exports.createInvisibleIframe = function() {
 	var f = refThis.createDocElement(window, 'iframe');

--- a/src_new/util.js
+++ b/src_new/util.js
@@ -689,7 +689,7 @@ exports.getBididForPMP = function(values, priorityArray){
 
 function insertElement(elm, doc, target, asLastChildChild) {
 	doc = doc || document;
-	let parentEl;
+	var parentEl;
 	if (target) {
 	  parentEl = doc.getElementsByTagName(target);
 	} else {
@@ -699,7 +699,7 @@ function insertElement(elm, doc, target, asLastChildChild) {
 	  parentEl = parentEl.length ? parentEl : doc.getElementsByTagName('body');
 	  if (parentEl.length) {
 		parentEl = parentEl[0];
-		let insertBeforeEl = asLastChildChild ? null : parentEl.firstChild;
+		var insertBeforeEl = asLastChildChild ? null : parentEl.firstChild;
 		return parentEl.insertBefore(elm, insertBeforeEl);
 	  }
 	} catch (e) {}
@@ -710,7 +710,7 @@ exports.insertHtmlIntoIframe = function(htmlCode) {
 	  return;
 	}
   
-	let iframe = document.createElement('iframe');
+	var iframe = document.createElement('iframe');
 	iframe.id = refThis.getUniqueIdentifierStr();
 	iframe.width = 0;
 	iframe.height = 0;


### PR DESCRIPTION
Changed the fireTracker to read and fire impTrackers from nativeResponse OR nativeResponse.eventtrackers.
The previous code was throwing an exception which was resulting into non-execution of the user auction details code.