### PR TITLE
Consent Management : Publisher running A/B test with liveIntent fails…

### DIFF
--- a/src_new/adapters/prebid.js
+++ b/src_new/adapters/prebid.js
@@ -1067,7 +1067,7 @@ function setPrebidConfig() {
 
 		refThis.getFloorsConfiguration(prebidConfig);
 		refThis.checkConfigLevelFloor(prebidConfig);
-		//refThis.assignUserSyncConfig(prebidConfig);
+		refThis.assignUserSyncConfig(prebidConfig);
 		//refThis.assignGdprConfigIfRequired(prebidConfig);
 		//refThis.assignCcpaConfigIfRequired(prebidConfig);
 		//refThis.assignGppConfigIfRequired(prebidConfig);
@@ -1085,20 +1085,18 @@ function setPrebidConfig() {
 		util.handleHook(CONSTANTS.HOOKS.PREBID_SET_CONFIG, [ prebidConfig ]);
 		//todo: stop supporting this hook let pubs use pbjs.requestBids hook
 		// do not set any config below this line as we are executing the hook above
-		
-		window[pbNameSpace].setConfig(prebidConfig);
+		// Some OW+ IH or IH pubs use this hook to add/remove identityPartner.
 
 		consentConfigResolver.getConsentManagementConfig(function (cmConfig) {
-			var postConsentPrebidConfig = {};
-			refThis.assignUserSyncConfig(postConsentPrebidConfig);
 			var cmEnabled = COMMON_CONFIG.consentManagentEnabled();
 			var message =  cmEnabled ? "setting" : "not setting";			
 			util.log("ConsentManagement: " + cmEnabled + ", " + message + " the consentManagement config: " + JSON.stringify(cmConfig));
 			if(cmConfig && !util.isEmptyObject(cmConfig)) {
-				// var consentManagementConf = {};
-				postConsentPrebidConfig.consentManagement = cmConfig;								
+				prebidConfig.consentManagement = cmConfig;								
 			}
-			window[pbNameSpace].setConfig(postConsentPrebidConfig);
+			// Setting complete config to prebid after consent management config is set.
+			// As UserSync config required to be set with consent due to userSync modules do required the consent 
+			window[pbNameSpace].setConfig(prebidConfig);
 		});
 
 	} else {


### PR DESCRIPTION
Consent Management : Publisher running A/B test with liveIntent fails to remove liveintent module but gets flagged as removed.
Due to handlehook was calling before preparing userSync config